### PR TITLE
feat: implement Markdown parser service

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -12,7 +12,7 @@
 - [ ] **S** MCP server scaffolding (package.json, tsconfig)
 - [x] **S** Web UI scaffolding (Next.js setup)
 - [x] **M** Vault manager service (read/write markdown files)
-- [ ] **M** Markdown parser (frontmatter, observations, relations)
+- [x] **M** Markdown parser (frontmatter, observations, relations)
 - [ ] **M** SQLite + FTS5 search index
 - [ ] **M** Basic CRUD API endpoints (/api/notes/*)
 - [ ] **L** MCP tools: mem_read, mem_write, mem_search

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,5 +1,15 @@
 """Pydantic models for data validation."""
 
+from app.models.note import (
+    Frontmatter,
+    NoteType,
+    Observation,
+    ObservationCategory,
+    ParsedNote,
+    Relation,
+    RelationType,
+    Wikilink,
+)
 from app.models.vault import (
     VaultConfig,
     VaultFile,
@@ -7,7 +17,15 @@ from app.models.vault import (
 )
 
 __all__ = [
+    "Frontmatter",
+    "NoteType",
+    "Observation",
+    "ObservationCategory",
+    "ParsedNote",
+    "Relation",
+    "RelationType",
     "VaultConfig",
     "VaultFile",
     "VaultManagerConfig",
+    "Wikilink",
 ]

--- a/backend/app/models/note.py
+++ b/backend/app/models/note.py
@@ -1,0 +1,139 @@
+"""Data models for parsed markdown notes."""
+
+from datetime import datetime
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+
+class NoteType(str, Enum):
+    """Note type enumeration."""
+
+    NOTE = "note"
+    DECISION = "decision"
+    ERROR = "error"
+    KNOWLEDGE = "knowledge"
+    PATTERN = "pattern"
+    SESSION = "session"
+    RESEARCH = "research"
+
+
+class ObservationCategory(str, Enum):
+    """Observation category enumeration."""
+
+    DECISION = "decision"
+    REASON = "reason"
+    TRADEOFF = "tradeoff"
+    IMPLEMENTATION = "implementation"
+    GOTCHA = "gotcha"
+    PATTERN = "pattern"
+    TIP = "tip"
+    FACT = "fact"
+    ERROR = "error"
+    SOLUTION = "solution"
+    EXPERIMENT = "experiment"
+    RESOURCE = "resource"
+    QUESTION = "question"
+    ANSWER = "answer"
+
+
+class RelationType(str, Enum):
+    """Relation type enumeration."""
+
+    DEPENDS_ON = "depends_on"
+    ENABLES = "enables"
+    RELATED_TO = "related_to"
+    LEARNED_FROM = "learned_from"
+    SUPERSEDES = "supersedes"
+    CAUSED_BY = "caused_by"
+    SOLVED_BY = "solved_by"
+    PART_OF = "part_of"
+    IMPLEMENTS = "implements"
+    TESTS = "tests"
+    DOCUMENTS = "documents"
+
+
+class Frontmatter(BaseModel):
+    """Parsed YAML frontmatter."""
+
+    title: str = Field(..., description="Note title")
+    type: NoteType = Field(default=NoteType.NOTE, description="Note type")
+    project: str | None = Field(default=None, description="Project identifier")
+    permalink: str | None = Field(
+        default=None, description="URL-safe slug for linking"
+    )
+    created: datetime | None = Field(default=None, description="Creation timestamp")
+    updated: datetime | None = Field(
+        default=None, description="Last update timestamp"
+    )
+    tags: list[str] = Field(default_factory=list, description="Categorization tags")
+    supersedes: str | None = Field(
+        default=None, description="Permalink of note this replaces"
+    )
+    superseded_by: str | None = Field(
+        default=None, description="Permalink of note that replaced this"
+    )
+    extra: dict = Field(
+        default_factory=dict, description="Any additional frontmatter fields"
+    )
+
+
+class Observation(BaseModel):
+    """A structured observation from note content."""
+
+    category: ObservationCategory = Field(..., description="Observation category")
+    content: str = Field(..., description="The observation text")
+    tags: list[str] = Field(
+        default_factory=list, description="Inline tags from content"
+    )
+    context: str | None = Field(
+        default=None, description="Additional context in parentheses"
+    )
+    line_number: int = Field(..., description="Line number for error reporting")
+
+
+class Relation(BaseModel):
+    """A semantic relation to another note."""
+
+    relation_type: RelationType = Field(..., description="Type of relation")
+    target: str = Field(..., description="Target note title/permalink")
+    target_path: str | None = Field(
+        default=None, description="Resolved path if wikilink had path"
+    )
+    context: str | None = Field(
+        default=None, description="Additional context in parentheses"
+    )
+    line_number: int = Field(..., description="Line number for error reporting")
+
+
+class Wikilink(BaseModel):
+    """A wikilink reference."""
+
+    target: str = Field(..., description="The linked note title")
+    display_text: str | None = Field(
+        default=None, description="Optional display text"
+    )
+    path: str | None = Field(
+        default=None, description="Optional folder path"
+    )
+    line_number: int = Field(..., description="Line number")
+    column: int = Field(..., description="Character position in line")
+
+
+class ParsedNote(BaseModel):
+    """Fully parsed note structure."""
+
+    frontmatter: Frontmatter = Field(..., description="Parsed frontmatter")
+    observations: list[Observation] = Field(
+        default_factory=list, description="Extracted observations"
+    )
+    relations: list[Relation] = Field(
+        default_factory=list, description="Extracted relations"
+    )
+    wikilinks: list[Wikilink] = Field(
+        default_factory=list, description="Extracted wikilinks"
+    )
+    raw_content: str = Field(..., description="Original content without frontmatter")
+    headings: list[tuple[int, str]] = Field(
+        default_factory=list, description="(level, text) pairs"
+    )

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,5 +1,6 @@
 """Service layer for business logic."""
 
+from app.services.markdown_parser import MarkdownParser
 from app.services.vault_manager import VaultManager
 
-__all__ = ["VaultManager"]
+__all__ = ["MarkdownParser", "VaultManager"]

--- a/backend/app/services/exceptions.py
+++ b/backend/app/services/exceptions.py
@@ -1,4 +1,4 @@
-"""Exception classes for vault operations."""
+"""Exception classes for vault and parsing operations."""
 
 
 class VaultError(Exception):
@@ -21,5 +21,34 @@ class VaultReadOnlyError(VaultError):
 
 class AtomicWriteError(VaultError):
     """Raised when atomic write fails (temp file, rename, etc.)."""
+
+    pass
+
+
+class ParseError(Exception):
+    """Base parsing error."""
+
+    def __init__(self, message: str, line_number: int | None = None) -> None:
+        self.line_number = line_number
+        if line_number:
+            super().__init__(f"Line {line_number}: {message}")
+        else:
+            super().__init__(message)
+
+
+class FrontmatterError(ParseError):
+    """Invalid YAML frontmatter."""
+
+    pass
+
+
+class InvalidObservationError(ParseError):
+    """Observation doesn't match expected format."""
+
+    pass
+
+
+class InvalidRelationError(ParseError):
+    """Relation doesn't match expected format."""
 
     pass

--- a/backend/app/services/markdown_parser.py
+++ b/backend/app/services/markdown_parser.py
@@ -1,0 +1,401 @@
+"""Markdown parser for Obsidian-compatible markdown files."""
+
+import re
+from datetime import datetime
+from typing import Any
+
+import frontmatter
+
+from app.models.note import (
+    Frontmatter,
+    NoteType,
+    Observation,
+    ObservationCategory,
+    ParsedNote,
+    Relation,
+    RelationType,
+    Wikilink,
+)
+from app.services.exceptions import (
+    FrontmatterError,
+    InvalidObservationError,
+    InvalidRelationError,
+)
+
+# Regex patterns
+FRONTMATTER_PATTERN = re.compile(
+    r'^---\s*\n(.*?)\n---\s*\n',
+    re.DOTALL | re.MULTILINE
+)
+
+OBSERVATION_PATTERN = re.compile(
+    r'^-\s*\[(\w+)\]\s*(.+?)(?:\s*\(([^)]+)\))?\s*$',
+    re.MULTILINE
+)
+
+RELATION_PATTERN = re.compile(
+    r'^-\s*(\w+)\s+\[\[([^\]|]+)(?:\|[^\]]+)?\]\](?:\s*\(([^)]+)\))?\s*$',
+    re.MULTILINE
+)
+
+WIKILINK_PATTERN = re.compile(
+    r'\[\[([^\]|]+)(?:\|([^\]]+))?\]\]'
+)
+
+HEADING_PATTERN = re.compile(
+    r'^(#{1,6})\s+(.+)$',
+    re.MULTILINE
+)
+
+INLINE_TAG_PATTERN = re.compile(
+    r'(?<!\S)#([\w-]+)(?!\S)'
+)
+
+
+class MarkdownParser:
+    """Parses Obsidian-compatible markdown files."""
+
+    def parse(self, content: str) -> ParsedNote:
+        """
+        Parse markdown content into structured data.
+
+        Args:
+            content: Raw markdown file content
+
+        Returns:
+            ParsedNote with all extracted structure
+
+        Raises:
+            ParseError: If frontmatter is invalid YAML
+        """
+        # Parse frontmatter
+        frontmatter_obj, raw_content = self.parse_frontmatter(content)
+
+        # Extract all structured data
+        observations = self.extract_observations(raw_content)
+        relations = self.extract_relations(raw_content)
+        wikilinks = self.extract_wikilinks(raw_content)
+        headings = self.extract_headings(raw_content)
+
+        return ParsedNote(
+            frontmatter=frontmatter_obj,
+            observations=observations,
+            relations=relations,
+            wikilinks=wikilinks,
+            raw_content=raw_content,
+            headings=headings,
+        )
+
+    def parse_frontmatter(self, content: str) -> tuple[Frontmatter, str]:
+        """
+        Extract and parse YAML frontmatter.
+
+        Args:
+            content: Raw markdown content
+
+        Returns:
+            Tuple of (parsed frontmatter, remaining content)
+
+        Raises:
+            FrontmatterError: If YAML is malformed
+        """
+        try:
+            post = frontmatter.loads(content)
+        except Exception as e:
+            raise FrontmatterError(f"Invalid YAML frontmatter: {e}") from e
+
+        # Extract known fields, put rest in extra
+        known_fields = {
+            'title',
+            'type',
+            'project',
+            'permalink',
+            'created',
+            'updated',
+            'tags',
+            'supersedes',
+            'superseded_by',
+        }
+        extra = {
+            k: v for k, v in post.metadata.items() if k not in known_fields
+        }
+
+        # Auto-generate permalink if missing
+        permalink = post.metadata.get('permalink')
+        if not permalink:
+            title = post.metadata.get('title', 'Untitled')
+            permalink = self.generate_permalink(title)
+
+        # Parse datetime fields
+        created = post.metadata.get('created')
+        if created and isinstance(created, str):
+            try:
+                created = datetime.fromisoformat(created.replace('Z', '+00:00'))
+            except ValueError:
+                created = None
+
+        updated = post.metadata.get('updated')
+        if updated and isinstance(updated, str):
+            try:
+                updated = datetime.fromisoformat(updated.replace('Z', '+00:00'))
+            except ValueError:
+                updated = None
+
+        # Parse note type
+        note_type = NoteType.NOTE
+        if 'type' in post.metadata:
+            try:
+                note_type = NoteType(post.metadata['type'])
+            except ValueError:
+                note_type = NoteType.NOTE
+
+        # Ensure tags is a list
+        tags = post.metadata.get('tags', [])
+        if not isinstance(tags, list):
+            tags = [tags] if tags else []
+
+        frontmatter_obj = Frontmatter(
+            title=post.metadata.get('title', 'Untitled'),
+            type=note_type,
+            project=post.metadata.get('project'),
+            permalink=permalink,
+            created=created,
+            updated=updated,
+            tags=tags,
+            supersedes=post.metadata.get('supersedes'),
+            superseded_by=post.metadata.get('superseded_by'),
+            extra=extra,
+        )
+
+        return frontmatter_obj, post.content
+
+    def extract_observations(self, content: str) -> list[Observation]:
+        """
+        Extract all observations from content.
+
+        Matches pattern: - [category] content #tags (context)
+        """
+        observations: list[Observation] = []
+        lines = content.split('\n')
+
+        for line_num, line in enumerate(lines, start=1):
+            match = OBSERVATION_PATTERN.match(line.strip())
+            if match:
+                category_str = match.group(1).lower()
+                content_text = match.group(2).strip()
+                context = match.group(3)
+
+                # Validate category
+                try:
+                    category = ObservationCategory(category_str)
+                except ValueError as e:
+                    raise InvalidObservationError(
+                        f"Invalid observation category: {category_str}",
+                        line_number=line_num,
+                    ) from e
+
+                # Parse inline tags from content
+                tags = self._parse_inline_tags(content_text)
+                # Remove all tags from content
+                content_text = INLINE_TAG_PATTERN.sub('', content_text)
+                # Clean up extra spaces
+                content_text = re.sub(r'\s+', ' ', content_text).strip()
+
+                observations.append(
+                    Observation(
+                        category=category,
+                        content=content_text,
+                        tags=tags,
+                        context=context,
+                        line_number=line_num,
+                    )
+                )
+
+        return observations
+
+    def extract_relations(self, content: str) -> list[Relation]:
+        """
+        Extract all semantic relations from content.
+
+        Matches pattern: - relation_type [[Target]]
+        """
+        relations: list[Relation] = []
+        lines = content.split('\n')
+
+        for line_num, line in enumerate(lines, start=1):
+            match = RELATION_PATTERN.match(line.strip())
+            if match:
+                relation_type_str = match.group(1).lower()
+                target = match.group(2).strip()
+                context = match.group(3)
+
+                # Validate relation type
+                try:
+                    relation_type = RelationType(relation_type_str)
+                except ValueError as e:
+                    raise InvalidRelationError(
+                        f"Invalid relation type: {relation_type_str}",
+                        line_number=line_num,
+                    ) from e
+
+                # Parse target path if present
+                target_path = None
+                if '/' in target:
+                    parts = target.rsplit('/', 1)
+                    if len(parts) == 2:
+                        target_path = parts[0]
+                        target = parts[1]
+
+                relations.append(
+                    Relation(
+                        relation_type=relation_type,
+                        target=target,
+                        target_path=target_path,
+                        context=context,
+                        line_number=line_num,
+                    )
+                )
+
+        return relations
+
+    def extract_wikilinks(self, content: str) -> list[Wikilink]:
+        """
+        Extract all wikilinks from content.
+
+        Matches patterns:
+        - [[Note Title]]
+        - [[Note Title|Display]]
+        - [[folder/Note Title]]
+        """
+        wikilinks: list[Wikilink] = []
+        lines = content.split('\n')
+
+        for line_num, line in enumerate(lines, start=1):
+            for match in WIKILINK_PATTERN.finditer(line):
+                target = match.group(1).strip()
+                display_text = match.group(2)
+
+                # Parse path if present
+                path = None
+                if '/' in target:
+                    parts = target.rsplit('/', 1)
+                    if len(parts) == 2:
+                        path = parts[0]
+                        target = parts[1]
+
+                column = match.start()
+
+                wikilinks.append(
+                    Wikilink(
+                        target=target,
+                        display_text=display_text,
+                        path=path,
+                        line_number=line_num,
+                        column=column,
+                    )
+                )
+
+        return wikilinks
+
+    def extract_headings(self, content: str) -> list[tuple[int, str]]:
+        """
+        Extract all markdown headings.
+
+        Returns list of (level, text) where level is 1-6.
+        """
+        headings: list[tuple[int, str]] = []
+        for match in HEADING_PATTERN.finditer(content):
+            level = len(match.group(1))
+            text = match.group(2).strip()
+            headings.append((level, text))
+        return headings
+
+    def generate_permalink(self, title: str) -> str:
+        """
+        Generate URL-safe permalink from title.
+
+        Rules:
+        - Lowercase
+        - Replace spaces with hyphens
+        - Remove special characters except hyphens
+        - Collapse multiple hyphens
+        """
+        # Lowercase
+        permalink = title.lower()
+
+        # Replace spaces and underscores with hyphens
+        permalink = re.sub(r'[\s_]+', '-', permalink)
+
+        # Remove special characters except hyphens
+        permalink = re.sub(r'[^a-z0-9-]', '', permalink)
+
+        # Collapse multiple hyphens
+        permalink = re.sub(r'-+', '-', permalink)
+
+        # Remove leading/trailing hyphens
+        permalink = permalink.strip('-')
+
+        return permalink or 'untitled'
+
+    def serialize(self, note: ParsedNote) -> str:
+        """
+        Serialize ParsedNote back to markdown.
+
+        Preserves original content structure while updating
+        frontmatter with any changes.
+        """
+        # Build frontmatter dict
+        metadata: dict[str, Any] = {
+            'title': note.frontmatter.title,
+            'type': note.frontmatter.type.value,
+        }
+
+        if note.frontmatter.project:
+            metadata['project'] = note.frontmatter.project
+        if note.frontmatter.permalink:
+            metadata['permalink'] = note.frontmatter.permalink
+        if note.frontmatter.created:
+            metadata['created'] = note.frontmatter.created.isoformat()
+        if note.frontmatter.updated:
+            metadata['updated'] = note.frontmatter.updated.isoformat()
+        if note.frontmatter.tags:
+            metadata['tags'] = note.frontmatter.tags
+        if note.frontmatter.supersedes:
+            metadata['supersedes'] = note.frontmatter.supersedes
+        if note.frontmatter.superseded_by:
+            metadata['superseded_by'] = note.frontmatter.superseded_by
+
+        # Add extra fields
+        metadata.update(note.frontmatter.extra)
+
+        # Create frontmatter post
+        post = frontmatter.Post(note.raw_content, **metadata)
+
+        return frontmatter.dumps(post)
+
+    def update_frontmatter(self, content: str, updates: dict[str, Any]) -> str:
+        """
+        Update frontmatter fields without reparsing entire note.
+
+        Useful for updating 'updated' timestamp on edits.
+        """
+        try:
+            post = frontmatter.loads(content)
+        except Exception as e:
+            raise FrontmatterError(f"Invalid YAML frontmatter: {e}") from e
+
+        # Update fields
+        post.metadata.update(updates)
+
+        return frontmatter.dumps(post)
+
+    def _parse_inline_tags(self, tags_str: str) -> list[str]:
+        """Parse inline tags from string like '#tag1 #tag2'."""
+        if not tags_str:
+            return []
+
+        tags: list[str] = []
+        for match in INLINE_TAG_PATTERN.finditer(tags_str):
+            tags.append(match.group(1))
+
+        return tags

--- a/backend/tests/services/test_markdown_parser.py
+++ b/backend/tests/services/test_markdown_parser.py
@@ -1,0 +1,362 @@
+"""Tests for MarkdownParser service."""
+
+from datetime import datetime
+
+import pytest
+
+from app.models.note import (
+    NoteType,
+    ObservationCategory,
+    RelationType,
+)
+from app.services.exceptions import (
+    FrontmatterError,
+    InvalidObservationError,
+    InvalidRelationError,
+)
+from app.services.markdown_parser import MarkdownParser
+
+
+@pytest.fixture
+def parser() -> MarkdownParser:
+    """Create a MarkdownParser instance."""
+    return MarkdownParser()
+
+
+def test_parse_frontmatter_valid(parser: MarkdownParser) -> None:
+    """Test parsing valid frontmatter."""
+    content = """---
+title: Test Note
+type: decision
+project: test-project
+permalink: test-note
+created: 2025-01-15T10:30:00Z
+updated: 2025-01-16T14:20:00Z
+tags:
+  - test
+  - parser
+---
+# Test Note
+
+Content here.
+"""
+    frontmatter, remaining = parser.parse_frontmatter(content)
+
+    assert frontmatter.title == "Test Note"
+    assert frontmatter.type == NoteType.DECISION
+    assert frontmatter.project == "test-project"
+    assert frontmatter.permalink == "test-note"
+    assert frontmatter.tags == ["test", "parser"]
+    assert "# Test Note" in remaining
+    assert "Content here." in remaining
+
+
+def test_parse_frontmatter_missing_title(parser: MarkdownParser) -> None:
+    """Test parsing frontmatter without title."""
+    content = """---
+type: note
+---
+# Content
+"""
+    frontmatter, _ = parser.parse_frontmatter(content)
+
+    assert frontmatter.title == "Untitled"
+    assert frontmatter.permalink is not None  # Auto-generated
+
+
+def test_parse_frontmatter_extra_fields(parser: MarkdownParser) -> None:
+    """Test parsing frontmatter with extra fields."""
+    content = """---
+title: Test
+custom_field: custom_value
+another_field: 123
+---
+Content
+"""
+    frontmatter, _ = parser.parse_frontmatter(content)
+
+    assert frontmatter.title == "Test"
+    assert frontmatter.extra["custom_field"] == "custom_value"
+    assert frontmatter.extra["another_field"] == 123
+
+
+def test_parse_frontmatter_invalid_yaml(parser: MarkdownParser) -> None:
+    """Test parsing invalid YAML frontmatter."""
+    content = """---
+title: Test
+invalid: [unclosed
+---
+Content
+"""
+    with pytest.raises(FrontmatterError):
+        parser.parse_frontmatter(content)
+
+
+def test_extract_observations_all_categories(parser: MarkdownParser) -> None:
+    """Test extracting observations with all categories."""
+    content = """- [decision] Chose JWT over sessions
+- [reason] Stateless API design
+- [tradeoff] Can't revoke tokens easily
+- [implementation] Using RS256
+- [gotcha] Token refresh needs Redis
+- [pattern] Middleware validates on every request
+- [tip] Set short expiry
+- [fact] JWT is industry standard
+- [error] Token validation failed
+- [solution] Use refresh tokens
+- [experiment] Tried session cookies first
+- [resource] https://jwt.io
+- [question] How to handle revocation?
+- [answer] Use blacklist
+"""
+    observations = parser.extract_observations(content)
+
+    assert len(observations) == 14
+    assert observations[0].category == ObservationCategory.DECISION
+    assert observations[1].category == ObservationCategory.REASON
+    assert observations[2].category == ObservationCategory.TRADEOFF
+
+
+def test_extract_observations_with_tags(parser: MarkdownParser) -> None:
+    """Test extracting observations with inline tags."""
+    content = """- [decision] Chose JWT #security #architecture
+- [tip] Set short expiry #security #best-practice
+"""
+    observations = parser.extract_observations(content)
+
+    assert len(observations) == 2
+    assert "security" in observations[0].tags
+    assert "architecture" in observations[0].tags
+    assert "security" in observations[1].tags
+    assert "best-practice" in observations[1].tags
+
+
+def test_extract_observations_with_context(parser: MarkdownParser) -> None:
+    """Test extracting observations with context."""
+    content = """- [implementation] Using RS256 (weekly rotation)
+- [gotcha] Token refresh needs Redis (for blacklist)
+"""
+    observations = parser.extract_observations(content)
+
+    assert len(observations) == 2
+    assert observations[0].context == "weekly rotation"
+    assert observations[1].context == "for blacklist"
+
+
+def test_extract_observations_invalid_category(parser: MarkdownParser) -> None:
+    """Test extracting observation with invalid category."""
+    content = """- [invalid] This should fail
+"""
+    with pytest.raises(InvalidObservationError):
+        parser.extract_observations(content)
+
+
+def test_extract_relations_all_types(parser: MarkdownParser) -> None:
+    """Test extracting relations with all types."""
+    content = """- depends_on [[redis-setup]]
+- enables [[api-gateway-auth]]
+- related_to [[user-authentication]]
+- learned_from [[session-scaling-issues]]
+- supersedes [[old-auth]]
+- caused_by [[token-leak]]
+- solved_by [[refresh-tokens]]
+- part_of [[auth-system]]
+- implements [[auth-spec]]
+- tests [[auth-service]]
+- documents [[auth-api]]
+"""
+    relations = parser.extract_relations(content)
+
+    assert len(relations) == 11
+    assert relations[0].relation_type == RelationType.DEPENDS_ON
+    assert relations[1].relation_type == RelationType.ENABLES
+    assert relations[2].relation_type == RelationType.RELATED_TO
+
+
+def test_extract_relations_with_context(parser: MarkdownParser) -> None:
+    """Test extracting relations with context."""
+    content = """- depends_on [[redis-setup]] (for blacklist)
+- enables [[api-gateway-auth]] (stateless design)
+"""
+    relations = parser.extract_relations(content)
+
+    assert len(relations) == 2
+    assert relations[0].context == "for blacklist"
+    assert relations[1].context == "stateless design"
+
+
+def test_extract_relations_with_path(parser: MarkdownParser) -> None:
+    """Test extracting relations with path."""
+    content = """- depends_on [[infrastructure/redis-setup]]
+"""
+    relations = parser.extract_relations(content)
+
+    assert len(relations) == 1
+    assert relations[0].target == "redis-setup"
+    assert relations[0].target_path == "infrastructure"
+
+
+def test_extract_relations_invalid_type(parser: MarkdownParser) -> None:
+    """Test extracting relation with invalid type."""
+    content = """- invalid_type [[target]]
+"""
+    with pytest.raises(InvalidRelationError):
+        parser.extract_relations(content)
+
+
+def test_extract_wikilinks_simple(parser: MarkdownParser) -> None:
+    """Test extracting simple wikilinks."""
+    content = """This references [[Note Title]] and [[Another Note]].
+"""
+    wikilinks = parser.extract_wikilinks(content)
+
+    assert len(wikilinks) == 2
+    assert wikilinks[0].target == "Note Title"
+    assert wikilinks[0].display_text is None
+    assert wikilinks[1].target == "Another Note"
+
+
+def test_extract_wikilinks_with_display(parser: MarkdownParser) -> None:
+    """Test extracting wikilinks with display text."""
+    content = """See [[Note Title|this note]] for details.
+"""
+    wikilinks = parser.extract_wikilinks(content)
+
+    assert len(wikilinks) == 1
+    assert wikilinks[0].target == "Note Title"
+    assert wikilinks[0].display_text == "this note"
+
+
+def test_extract_wikilinks_with_path(parser: MarkdownParser) -> None:
+    """Test extracting wikilinks with path."""
+    content = """See [[folder/Note Title]] for details.
+"""
+    wikilinks = parser.extract_wikilinks(content)
+
+    assert len(wikilinks) == 1
+    assert wikilinks[0].target == "Note Title"
+    assert wikilinks[0].path == "folder"
+
+
+def test_extract_headings(parser: MarkdownParser) -> None:
+    """Test extracting headings."""
+    content = """# Heading 1
+## Heading 2
+### Heading 3
+#### Heading 4
+##### Heading 5
+###### Heading 6
+"""
+    headings = parser.extract_headings(content)
+
+    assert len(headings) == 6
+    assert headings[0] == (1, "Heading 1")
+    assert headings[1] == (2, "Heading 2")
+    assert headings[5] == (6, "Heading 6")
+
+
+def test_generate_permalink(parser: MarkdownParser) -> None:
+    """Test permalink generation."""
+    assert parser.generate_permalink("Test Note") == "test-note"
+    assert parser.generate_permalink("JWT Authentication") == "jwt-authentication"
+    assert parser.generate_permalink("API v2.0") == "api-v20"
+    assert parser.generate_permalink("Test---Note") == "test-note"
+    assert parser.generate_permalink("  Test Note  ") == "test-note"
+    assert parser.generate_permalink("") == "untitled"
+
+
+def test_parse_full_note(parser: MarkdownParser) -> None:
+    """Test parsing a complete note."""
+    content = """---
+title: Authentication JWT Implementation
+type: decision
+project: api-service
+permalink: auth-jwt-impl
+created: 2025-01-15T10:30:00Z
+updated: 2025-01-16T14:20:00Z
+tags:
+  - security
+  - backend
+  - architecture
+supersedes: auth-session-cookies
+---
+
+# Authentication JWT Implementation
+
+## Context
+
+Migrating from session-based to JWT authentication for API service.
+
+- [decision] Chose JWT over session cookies for stateless API #architecture
+- [reason] Horizontal scaling without shared session store #scalability
+- [tradeoff] Tokens can't be revoked without blacklist #security
+
+## Observations
+
+- [implementation] Using RS256 with rotating keys #security (weekly rotation)
+- [gotcha] Token refresh needs Redis for blacklist #infrastructure
+- [pattern] Middleware validates on every request #performance
+- [tip] Set short expiry (15min) with refresh tokens #security
+
+## Relations
+
+- depends_on [[redis-setup]]
+- enables [[api-gateway-auth]]
+- learned_from [[session-scaling-issues]]
+- related_to [[user-authentication]]
+
+## Session Log
+
+### 2025-01-15 10:30
+
+Implemented base JWT service with refresh tokens. Used python-jose library.
+
+### 2025-01-16 09:00
+
+Added key rotation mechanism. Keys stored in Vault.
+"""
+    note = parser.parse(content)
+
+    assert note.frontmatter.title == "Authentication JWT Implementation"
+    assert note.frontmatter.type == NoteType.DECISION
+    assert len(note.observations) == 7
+    assert len(note.relations) == 4
+    assert len(note.wikilinks) == 4  # 4 from relations section
+    assert len(note.headings) == 7  # 1 h1, 4 h2, 2 h3
+
+
+def test_serialize_roundtrip(parser: MarkdownParser) -> None:
+    """Test serializing and parsing back."""
+    original = """---
+title: Test Note
+type: decision
+tags:
+  - test
+---
+# Test Note
+
+Content here.
+"""
+    note = parser.parse(original)
+    serialized = parser.serialize(note)
+    note2 = parser.parse(serialized)
+
+    assert note2.frontmatter.title == note.frontmatter.title
+    assert note2.frontmatter.type == note.frontmatter.type
+    assert note2.frontmatter.tags == note.frontmatter.tags
+
+
+def test_update_frontmatter(parser: MarkdownParser) -> None:
+    """Test updating frontmatter fields."""
+    content = """---
+title: Test Note
+---
+Content
+"""
+    updated = parser.update_frontmatter(
+        content, {'updated': '2025-01-15T10:30:00Z'}
+    )
+    note = parser.parse(updated)
+
+    assert note.frontmatter.title == "Test Note"
+    assert note.frontmatter.updated is not None


### PR DESCRIPTION
Implements comprehensive Markdown parser for Obsidian-compatible markdown files.

- Add data models (ParsedNote, Frontmatter, Observation, Relation, Wikilink, enums)
- Add ParseError exception classes
- Implement MarkdownParser with full parsing capabilities
- Add comprehensive test suite (20 tests, all passing)