### PR TITLE
feat: implement graph engine for knowledge graph

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -20,7 +20,7 @@
 ## Phase 2: Knowledge Graph
 
 ### Priority: High
-- [ ] **M** Graph engine (compute nodes/edges from markdown)
+- [x] **M** Graph engine (compute nodes/edges from markdown)
 - [ ] **M** Wikilink extraction and resolution
 - [ ] **M** Relation parsing from markdown
 - [ ] **M** Graph traversal queries

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,5 +1,11 @@
 """Pydantic models for data validation."""
 
+from app.models.graph import (
+    Edge,
+    EdgeType,
+    Graph,
+    Node,
+)
 from app.models.note import (
     Frontmatter,
     NoteType,
@@ -10,6 +16,13 @@ from app.models.note import (
     RelationType,
     Wikilink,
 )
+from app.models.search import (
+    IndexedNote,
+    SearchQuery,
+    SearchResult,
+    SearchResults,
+    SortOrder,
+)
 from app.models.vault import (
     VaultConfig,
     VaultFile,
@@ -17,13 +30,22 @@ from app.models.vault import (
 )
 
 __all__ = [
+    "Edge",
+    "EdgeType",
     "Frontmatter",
+    "Graph",
+    "IndexedNote",
+    "Node",
     "NoteType",
     "Observation",
     "ObservationCategory",
     "ParsedNote",
     "Relation",
     "RelationType",
+    "SearchQuery",
+    "SearchResult",
+    "SearchResults",
+    "SortOrder",
     "VaultConfig",
     "VaultFile",
     "VaultManagerConfig",

--- a/backend/app/models/graph.py
+++ b/backend/app/models/graph.py
@@ -1,0 +1,70 @@
+"""Data models for knowledge graph."""
+
+from datetime import datetime
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+
+class EdgeType(str, Enum):
+    """Type of edge in the knowledge graph."""
+
+    # Relation-based edges
+    DEPENDS_ON = "depends_on"
+    ENABLES = "enables"
+    RELATED_TO = "related_to"
+    LEARNED_FROM = "learned_from"
+    SUPERSEDES = "supersedes"
+    CAUSED_BY = "caused_by"
+    SOLVED_BY = "solved_by"
+    PART_OF = "part_of"
+    IMPLEMENTS = "implements"
+    TESTS = "tests"
+    DOCUMENTS = "documents"
+
+    # Wikilink-based edges
+    LINKS_TO = "links_to"  # Generic wikilink
+    BACKLINK = "backlink"  # Reverse of links_to
+
+
+class Node(BaseModel):
+    """A node in the knowledge graph representing a note."""
+
+    id: int | None = Field(default=None, description="Note ID from index")
+    title: str = Field(..., description="Note title")
+    permalink: str | None = Field(default=None, description="Permalink")
+    vault_name: str = Field(..., description="Vault name")
+    relative_path: str = Field(..., description="Relative path")
+    note_type: str = Field(..., description="Note type")
+    project: str | None = Field(default=None, description="Project")
+    tags: list[str] = Field(default_factory=list, description="Tags")
+    created_at: datetime | None = Field(default=None, description="Created at")
+    updated_at: datetime | None = Field(default=None, description="Updated at")
+
+
+class Edge(BaseModel):
+    """An edge in the knowledge graph representing a relationship."""
+
+    source_id: int = Field(..., description="Source note ID")
+    target_id: int | None = Field(default=None, description="Target note ID (if resolved)")
+    target_title: str = Field(..., description="Target note title")
+    edge_type: EdgeType = Field(..., description="Type of edge")
+    context: str | None = Field(default=None, description="Additional context")
+    weight: float = Field(default=1.0, description="Edge weight (for ranking)")
+
+
+class Graph(BaseModel):
+    """Knowledge graph structure."""
+
+    nodes: dict[int, Node] = Field(
+        default_factory=dict, description="Nodes by ID"
+    )
+    edges: list[Edge] = Field(
+        default_factory=list, description="List of edges"
+    )
+    title_to_id: dict[str, int] = Field(
+        default_factory=dict, description="Title to ID mapping"
+    )
+    permalink_to_id: dict[str, int] = Field(
+        default_factory=dict, description="Permalink to ID mapping"
+    )

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,7 +1,8 @@
 """Service layer for business logic."""
 
+from app.services.graph_engine import GraphEngine
 from app.services.markdown_parser import MarkdownParser
 from app.services.search_index import SearchIndex
 from app.services.vault_manager import VaultManager
 
-__all__ = ["MarkdownParser", "SearchIndex", "VaultManager"]
+__all__ = ["GraphEngine", "MarkdownParser", "SearchIndex", "VaultManager"]

--- a/backend/app/services/graph_engine.py
+++ b/backend/app/services/graph_engine.py
@@ -1,0 +1,143 @@
+"""Graph engine for computing knowledge graph from markdown notes."""
+
+from app.models.graph import Edge, EdgeType, Graph, Node
+from app.models.note import ParsedNote, Relation, RelationType, Wikilink
+from app.models.search import IndexedNote
+
+
+class GraphEngine:
+    """Computes and maintains knowledge graph from markdown notes."""
+
+    def __init__(self) -> None:
+        """Initialize graph engine."""
+        self.graph = Graph()
+
+    def add_note(
+        self, note_id: int, indexed_note: IndexedNote, parsed_note: ParsedNote
+    ) -> None:
+        """
+        Add a note to the graph, creating nodes and edges.
+
+        Args:
+            note_id: Note ID from search index
+            indexed_note: Indexed note with metadata
+            parsed_note: Parsed note with relations and wikilinks
+        """
+
+        # Create or update node
+        node = Node(
+            id=note_id,
+            title=parsed_note.frontmatter.title,
+            permalink=parsed_note.frontmatter.permalink,
+            vault_name=indexed_note.vault_name,
+            relative_path=indexed_note.relative_path,
+            note_type=parsed_note.frontmatter.type.value,
+            project=parsed_note.frontmatter.project,
+            tags=parsed_note.frontmatter.tags,
+            created_at=indexed_note.created_at,
+            updated_at=indexed_note.updated_at,
+        )
+
+        self.graph.nodes[note_id] = node
+
+        # Update mappings
+        if parsed_note.frontmatter.title:
+            self.graph.title_to_id[parsed_note.frontmatter.title] = note_id
+        if parsed_note.frontmatter.permalink:
+            self.graph.permalink_to_id[
+                parsed_note.frontmatter.permalink
+            ] = note_id
+
+        # Create edges from relations
+        for relation in parsed_note.relations:
+            edge = Edge(
+                source_id=note_id,
+                target_id=None,  # Will be resolved later
+                target_title=relation.target,
+                edge_type=EdgeType(relation.relation_type.value),
+                context=relation.context,
+                weight=1.0,
+            )
+            self.graph.edges.append(edge)
+
+        # Create edges from wikilinks
+        for wikilink in parsed_note.wikilinks:
+            edge = Edge(
+                source_id=note_id,
+                target_id=None,  # Will be resolved later
+                target_title=wikilink.target,
+                edge_type=EdgeType.LINKS_TO,
+                context=None,
+                weight=0.5,  # Wikilinks are weaker than explicit relations
+            )
+            self.graph.edges.append(edge)
+
+    def resolve_edges(self) -> None:
+        """Resolve target IDs for all edges using title and permalink mappings."""
+        for edge in self.graph.edges:
+            if edge.target_id is not None:
+                continue  # Already resolved
+
+            # Try to resolve by title
+            if edge.target_title in self.graph.title_to_id:
+                edge.target_id = self.graph.title_to_id[edge.target_title]
+                continue
+
+            # Try to resolve by permalink (if target_title looks like a permalink)
+            if edge.target_title in self.graph.permalink_to_id:
+                edge.target_id = self.graph.permalink_to_id[edge.target_title]
+
+    def remove_note(self, note_id: int) -> None:
+        """Remove a note and all its edges from the graph."""
+        if note_id not in self.graph.nodes:
+            return
+
+        # Remove node
+        node = self.graph.nodes[note_id]
+        del self.graph.nodes[note_id]
+
+        # Remove from mappings
+        if node.title in self.graph.title_to_id:
+            if self.graph.title_to_id[node.title] == note_id:
+                del self.graph.title_to_id[node.title]
+
+        if node.permalink and node.permalink in self.graph.permalink_to_id:
+            if self.graph.permalink_to_id[node.permalink] == note_id:
+                del self.graph.permalink_to_id[node.permalink]
+
+        # Remove edges
+        self.graph.edges = [
+            e for e in self.graph.edges if e.source_id != note_id and e.target_id != note_id
+        ]
+
+    def get_node(self, note_id: int) -> Node | None:
+        """Get a node by ID."""
+        return self.graph.nodes.get(note_id)
+
+    def get_outgoing_edges(self, note_id: int) -> list[Edge]:
+        """Get all outgoing edges from a node."""
+        return [e for e in self.graph.edges if e.source_id == note_id]
+
+    def get_incoming_edges(self, note_id: int) -> list[Edge]:
+        """Get all incoming edges to a node."""
+        return [e for e in self.graph.edges if e.target_id == note_id]
+
+    def get_neighbors(self, note_id: int) -> list[int]:
+        """Get all neighbor node IDs (both incoming and outgoing)."""
+        neighbors: set[int] = set()
+
+        for edge in self.graph.edges:
+            if edge.source_id == note_id and edge.target_id is not None:
+                neighbors.add(edge.target_id)
+            elif edge.target_id == note_id:
+                neighbors.add(edge.source_id)
+
+        return list(neighbors)
+
+    def get_graph(self) -> Graph:
+        """Get the current graph."""
+        return self.graph
+
+    def clear(self) -> None:
+        """Clear the entire graph."""
+        self.graph = Graph()

--- a/backend/tests/services/test_graph_engine.py
+++ b/backend/tests/services/test_graph_engine.py
@@ -1,0 +1,414 @@
+"""Tests for GraphEngine service."""
+
+from datetime import datetime
+
+import pytest
+
+from app.models.graph import EdgeType, Graph
+from app.models.note import (
+    NoteType,
+    Observation,
+    ObservationCategory,
+    ParsedNote,
+    Relation,
+    RelationType,
+    Wikilink,
+)
+from app.models.search import IndexedNote
+from app.services.graph_engine import GraphEngine
+from app.services.search_index import compute_file_hash
+
+
+@pytest.fixture
+def graph_engine() -> GraphEngine:
+    """Create a GraphEngine instance."""
+    return GraphEngine()
+
+
+@pytest.fixture
+def sample_indexed_note() -> IndexedNote:
+    """Create a sample indexed note."""
+    return IndexedNote(
+        vault_name="test_vault",
+        relative_path="test-note.md",
+        permalink="test-note",
+        title="Test Note",
+        note_type="note",
+        project="test-project",
+        content="Test content",
+        tags=["test"],
+        observations=[],
+        relations=[],
+        wikilinks=[],
+        created_at=datetime(2025, 1, 15, 10, 30, 0),
+        updated_at=datetime(2025, 1, 16, 14, 20, 0),
+        file_hash=compute_file_hash("test"),
+    )
+
+
+@pytest.fixture
+def sample_parsed_note() -> ParsedNote:
+    """Create a sample parsed note."""
+    from app.models.note import Frontmatter
+
+    return ParsedNote(
+        frontmatter=Frontmatter(
+            title="Test Note",
+            type=NoteType.NOTE,
+            project="test-project",
+            permalink="test-note",
+            tags=["test"],
+        ),
+        observations=[],
+        relations=[],
+        wikilinks=[],
+        raw_content="Test content",
+        headings=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_add_note_creates_node(
+    graph_engine: GraphEngine,
+    sample_indexed_note: IndexedNote,
+    sample_parsed_note: ParsedNote,
+) -> None:
+    """Test that adding a note creates a node."""
+    graph_engine.add_note(1, sample_indexed_note, sample_parsed_note)
+
+    node = graph_engine.get_node(1)
+    assert node is not None
+    assert node.title == "Test Note"
+    assert node.permalink == "test-note"
+    assert node.vault_name == "test_vault"
+
+
+@pytest.mark.asyncio
+async def test_add_note_updates_mappings(
+    graph_engine: GraphEngine,
+    sample_indexed_note: IndexedNote,
+    sample_parsed_note: ParsedNote,
+) -> None:
+    """Test that adding a note updates title and permalink mappings."""
+    graph_engine.add_note(1, sample_indexed_note, sample_parsed_note)
+
+    assert graph_engine.graph.title_to_id["Test Note"] == 1
+    assert graph_engine.graph.permalink_to_id["test-note"] == 1
+
+
+@pytest.mark.asyncio
+async def test_add_note_with_relations_creates_edges(
+    graph_engine: GraphEngine,
+    sample_indexed_note: IndexedNote,
+) -> None:
+    """Test that adding a note with relations creates edges."""
+    from app.models.note import Frontmatter
+
+    parsed_note = ParsedNote(
+        frontmatter=Frontmatter(title="Test Note", permalink="test-note"),
+        observations=[],
+        relations=[
+            Relation(
+                relation_type=RelationType.DEPENDS_ON,
+                target="Other Note",
+                target_path=None,
+                context=None,
+                line_number=1,
+            )
+        ],
+        wikilinks=[],
+        raw_content="",
+        headings=[],
+    )
+
+    graph_engine.add_note(1, sample_indexed_note, parsed_note)
+
+    edges = graph_engine.get_outgoing_edges(1)
+    assert len(edges) == 1
+    assert edges[0].edge_type == EdgeType.DEPENDS_ON
+    assert edges[0].target_title == "Other Note"
+
+
+@pytest.mark.asyncio
+async def test_add_note_with_wikilinks_creates_edges(
+    graph_engine: GraphEngine,
+    sample_indexed_note: IndexedNote,
+) -> None:
+    """Test that adding a note with wikilinks creates edges."""
+    from app.models.note import Frontmatter
+
+    parsed_note = ParsedNote(
+        frontmatter=Frontmatter(title="Test Note", permalink="test-note"),
+        observations=[],
+        relations=[],
+        wikilinks=[
+            Wikilink(
+                target="Linked Note",
+                display_text=None,
+                path=None,
+                line_number=1,
+                column=0,
+            )
+        ],
+        raw_content="",
+        headings=[],
+    )
+
+    graph_engine.add_note(1, sample_indexed_note, parsed_note)
+
+    edges = graph_engine.get_outgoing_edges(1)
+    assert len(edges) == 1
+    assert edges[0].edge_type == EdgeType.LINKS_TO
+    assert edges[0].target_title == "Linked Note"
+    assert edges[0].weight == 0.5  # Wikilinks have lower weight
+
+
+@pytest.mark.asyncio
+async def test_resolve_edges(
+    graph_engine: GraphEngine,
+) -> None:
+    """Test that resolve_edges resolves target IDs."""
+    from app.models.note import Frontmatter
+
+    # Add first note
+    note1 = IndexedNote(
+        id=1,
+        vault_name="test_vault",
+        relative_path="note1.md",
+        permalink="note1",
+        title="Note 1",
+        note_type="note",
+        project=None,
+        content="",
+        tags=[],
+        observations=[],
+        relations=[],
+        wikilinks=[],
+        created_at=None,
+        updated_at=None,
+        file_hash="",
+    )
+    parsed1 = ParsedNote(
+        frontmatter=Frontmatter(title="Note 1", permalink="note1"),
+        observations=[],
+        relations=[],
+        wikilinks=[],
+        raw_content="",
+        headings=[],
+    )
+    graph_engine.add_note(1, note1, parsed1)
+
+    # Add second note that links to first
+    note2 = IndexedNote(
+        vault_name="test_vault",
+        relative_path="note2.md",
+        permalink="note2",
+        title="Note 2",
+        note_type="note",
+        project=None,
+        content="",
+        tags=[],
+        observations=[],
+        relations=[
+            Relation(
+                relation_type=RelationType.DEPENDS_ON,
+                target="Note 1",
+                target_path=None,
+                context=None,
+                line_number=1,
+            )
+        ],
+        wikilinks=[],
+        created_at=None,
+        updated_at=None,
+        file_hash="",
+    )
+    parsed2 = ParsedNote(
+        frontmatter=Frontmatter(title="Note 2", permalink="note2"),
+        observations=[],
+        relations=parsed2.relations if 'parsed2' in locals() else [],
+        wikilinks=[],
+        raw_content="",
+        headings=[],
+    )
+    # Fix: use the relations from note2
+    parsed2.relations = note2.relations
+    graph_engine.add_note(2, note2, parsed2)
+
+    # Resolve edges
+    graph_engine.resolve_edges()
+
+    # Check that edge is resolved
+    edges = graph_engine.get_outgoing_edges(2)
+    assert len(edges) == 1
+    assert edges[0].target_id == 1
+
+
+@pytest.mark.asyncio
+async def test_remove_note(
+    graph_engine: GraphEngine,
+    sample_indexed_note: IndexedNote,
+    sample_parsed_note: ParsedNote,
+) -> None:
+    """Test that removing a note removes it and its edges."""
+    graph_engine.add_note(1, sample_indexed_note, sample_parsed_note)
+
+    assert graph_engine.get_node(1) is not None
+
+    graph_engine.remove_note(1)
+
+    assert graph_engine.get_node(1) is None
+    assert "Test Note" not in graph_engine.graph.title_to_id
+    assert "test-note" not in graph_engine.graph.permalink_to_id
+
+
+@pytest.mark.asyncio
+async def test_get_neighbors(
+    graph_engine: GraphEngine,
+) -> None:
+    """Test getting neighbor nodes."""
+    from app.models.note import Frontmatter
+
+    # Create three connected notes
+    note1 = IndexedNote(
+        vault_name="test_vault",
+        relative_path="note1.md",
+        permalink="note1",
+        title="Note 1",
+        note_type="note",
+        project=None,
+        content="",
+        tags=[],
+        observations=[],
+        relations=[],
+        wikilinks=[],
+        created_at=None,
+        updated_at=None,
+        file_hash="",
+    )
+    parsed1 = ParsedNote(
+        frontmatter=Frontmatter(title="Note 1", permalink="note1"),
+        observations=[],
+        relations=[],
+        wikilinks=[],
+        raw_content="",
+        headings=[],
+    )
+    graph_engine.add_note(1, note1, parsed1)
+
+    note2 = IndexedNote(
+        id=2,
+        vault_name="test_vault",
+        relative_path="note2.md",
+        permalink="note2",
+        title="Note 2",
+        note_type="note",
+        project=None,
+        content="",
+        tags=[],
+        observations=[],
+        relations=[
+            Relation(
+                relation_type=RelationType.DEPENDS_ON,
+                target="Note 1",
+                target_path=None,
+                context=None,
+                line_number=1,
+            )
+        ],
+        wikilinks=[],
+        created_at=None,
+        updated_at=None,
+        file_hash="",
+    )
+    parsed2 = ParsedNote(
+        frontmatter=Frontmatter(title="Note 2", permalink="note2"),
+        observations=[],
+        relations=note2.relations,
+        wikilinks=[],
+        raw_content="",
+        headings=[],
+    )
+    graph_engine.add_note(2, note2, parsed2)
+
+    graph_engine.resolve_edges()
+
+    neighbors = graph_engine.get_neighbors(1)
+    assert 2 in neighbors
+
+    neighbors = graph_engine.get_neighbors(2)
+    assert 1 in neighbors
+
+
+@pytest.mark.asyncio
+async def test_get_incoming_edges(
+    graph_engine: GraphEngine,
+) -> None:
+    """Test getting incoming edges."""
+    from app.models.note import Frontmatter
+
+    note1 = IndexedNote(
+        vault_name="test_vault",
+        relative_path="note1.md",
+        permalink="note1",
+        title="Note 1",
+        note_type="note",
+        project=None,
+        content="",
+        tags=[],
+        observations=[],
+        relations=[],
+        wikilinks=[],
+        created_at=None,
+        updated_at=None,
+        file_hash="",
+    )
+    parsed1 = ParsedNote(
+        frontmatter=Frontmatter(title="Note 1", permalink="note1"),
+        observations=[],
+        relations=[],
+        wikilinks=[],
+        raw_content="",
+        headings=[],
+    )
+    graph_engine.add_note(1, note1, parsed1)
+
+    note2 = IndexedNote(
+        vault_name="test_vault",
+        relative_path="note2.md",
+        permalink="note2",
+        title="Note 2",
+        note_type="note",
+        project=None,
+        content="",
+        tags=[],
+        observations=[],
+        relations=[
+            Relation(
+                relation_type=RelationType.DEPENDS_ON,
+                target="Note 1",
+                target_path=None,
+                context=None,
+                line_number=1,
+            )
+        ],
+        wikilinks=[],
+        created_at=None,
+        updated_at=None,
+        file_hash="",
+    )
+    parsed2 = ParsedNote(
+        frontmatter=Frontmatter(title="Note 2", permalink="note2"),
+        observations=[],
+        relations=note2.relations,
+        wikilinks=[],
+        raw_content="",
+        headings=[],
+    )
+    graph_engine.add_note(2, note2, parsed2)
+
+    graph_engine.resolve_edges()
+
+    incoming = graph_engine.get_incoming_edges(1)
+    assert len(incoming) == 1
+    assert incoming[0].source_id == 2


### PR DESCRIPTION
Implements graph engine to compute knowledge graph from markdown notes.

- Add data models (Node, Edge, Graph)
- Implement node/edge creation from relations and wikilinks
- Add edge resolution and graph traversal methods
- Add comprehensive test suite