### PR TITLE
feat: implement project management tools for MCP server

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -36,7 +36,15 @@
 - [x] **M** Session summarization
 - [x] **L** Pattern detection
 
-## Phase 4-8: See specs/ for details
+## Phase 4: MCP Server
+
+### Priority: High
+- [x] **L** Graph tools integration (graph_traverse, graph_similar)
+- [x] **M** Project tools (project_list, project_switch, project_create)
+- [ ] **L** Session tools (session_observe, session_summary, session_context)
+- [ ] **M** SSE transport support
+
+## Phase 5-8: See specs/ for details
 
 ---
 

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -1,0 +1,124 @@
+"""Project management API endpoints."""
+
+from typing import Any
+
+from fastapi import APIRouter, Body, Depends, HTTPException
+
+from app.api.dependencies import get_search_index
+from app.services.search_index import SearchIndex
+
+router = APIRouter(prefix="/api/projects", tags=["projects"])
+
+
+@router.get("")
+async def list_projects(
+    search_index: SearchIndex = Depends(get_search_index),
+) -> dict[str, list[dict[str, Any]]]:
+    """List all projects with note counts.
+
+    Returns:
+        Dictionary with 'projects' list containing project names and counts
+    """
+    await search_index.initialize()
+    projects = await search_index.list_projects()
+
+    return {
+        "projects": [
+            {"name": name, "note_count": count} for name, count in projects
+        ]
+    }
+
+
+@router.get("/{project_name}/notes")
+async def list_project_notes(
+    project_name: str,
+    limit: int = 50,
+    offset: int = 0,
+    search_index: SearchIndex = Depends(get_search_index),
+) -> dict[str, Any]:
+    """List notes for a specific project.
+
+    Args:
+        project_name: Name of the project
+        limit: Maximum number of notes to return
+        offset: Offset for pagination
+        search_index: Search index dependency
+
+    Returns:
+        Dictionary with 'notes' list and pagination info
+    """
+    await search_index.initialize()
+
+    # Use get_recent_notes with project filter
+    recent_notes = await search_index.get_recent_notes(
+        limit=limit + offset,  # Get enough to handle offset
+        project=project_name,
+    )
+
+    # Apply offset manually (get_recent_notes doesn't support offset)
+    if offset > 0 and offset < len(recent_notes):
+        recent_notes = recent_notes[offset:]
+    elif offset >= len(recent_notes):
+        recent_notes = []
+
+    # Limit to requested limit
+    if len(recent_notes) > limit:
+        recent_notes = recent_notes[:limit]
+
+    # Get total count by querying projects
+    projects = await search_index.list_projects()
+    project_info = next((p for p in projects if p[0] == project_name), None)
+    total_count = project_info[1] if project_info else 0
+
+    return {
+        "project": project_name,
+        "notes": [
+            {
+                "note_id": r.note_id,
+                "title": r.title,
+                "permalink": r.permalink,
+                "note_type": r.note_type,
+                "updated_at": r.updated_at.isoformat() if r.updated_at else None,
+            }
+            for r in recent_notes
+        ],
+        "total_count": total_count,
+        "limit": limit,
+        "offset": offset,
+    }
+
+
+@router.post("")
+async def create_project(
+    project_name: str = Body(..., embed=True),
+    search_index: SearchIndex = Depends(get_search_index),
+) -> dict[str, str]:
+    """Create a new project (implicitly by creating a note with that project).
+
+    Note: Projects are created implicitly when notes are created with a project field.
+    This endpoint just validates that the project name is valid.
+
+    Args:
+        project_name: Name of the project to create
+        search_index: Search index dependency
+
+    Returns:
+        Dictionary with project name and status
+    """
+    if not project_name or not project_name.strip():
+        raise HTTPException(status_code=400, detail="Project name cannot be empty")
+
+    # Validate project name (alphanumeric, dash, underscore)
+    import re
+
+    if not re.match(r"^[a-zA-Z0-9_-]+$", project_name):
+        raise HTTPException(
+            status_code=400,
+            detail="Project name must contain only alphanumeric characters, dashes, and underscores",
+        )
+
+    return {
+        "project": project_name,
+        "status": "created",
+        "message": "Project will be created when first note is added to it",
+    }

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,7 @@
 from fastapi import FastAPI
 
 from app.api.notes import router as notes_router
+from app.api.projects import router as projects_router
 from app.config import settings
 
 app = FastAPI(
@@ -14,6 +15,7 @@ app = FastAPI(
 
 # Include routers
 app.include_router(notes_router)
+app.include_router(projects_router)
 
 
 @app.get("/")

--- a/backend/tests/api/test_projects.py
+++ b/backend/tests/api/test_projects.py
@@ -1,0 +1,159 @@
+"""Tests for project management API endpoints."""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+
+
+@pytest.fixture
+async def client():
+    """Create test client."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        yield ac
+
+
+@pytest.mark.asyncio
+async def test_list_projects_empty(client: AsyncClient, tmp_path, monkeypatch):
+    """Test listing projects when none exist."""
+    import tempfile
+
+    from app.config import settings
+    from pathlib import Path
+
+    # Use temporary database
+    db_path = tmp_path / "test_index.db"
+    monkeypatch.setattr(settings, "index_db_path", db_path)
+
+    response = await client.get("/api/projects")
+    assert response.status_code == 200
+    data = response.json()
+    assert "projects" in data
+    assert isinstance(data["projects"], list)
+
+
+@pytest.mark.asyncio
+async def test_list_projects_with_data(client: AsyncClient, tmp_path, monkeypatch):
+    """Test listing projects with existing notes."""
+    import tempfile
+
+    from app.config import settings
+    from app.services.search_index import SearchIndex
+    from app.models.search import IndexedNote
+    from pathlib import Path
+
+    # Use temporary database
+    db_path = tmp_path / "test_index.db"
+    monkeypatch.setattr(settings, "index_db_path", db_path)
+
+    # Create index and add a note with a project
+    index = SearchIndex(db_path)
+    await index.initialize()
+
+    indexed_note = IndexedNote(
+        vault_name="test_vault",
+        relative_path="test_note.md",
+        title="Test Note",
+        note_type="note",
+        project="test-project",
+        content="Test content",
+        tags=[],
+        file_hash="test_hash",
+    )
+
+    await index.index_note(indexed_note)
+    await index.close()
+
+    response = await client.get("/api/projects")
+    assert response.status_code == 200
+    data = response.json()
+    assert "projects" in data
+    assert len(data["projects"]) >= 1
+    assert any(p["name"] == "test-project" for p in data["projects"])
+
+
+@pytest.mark.asyncio
+async def test_list_project_notes(client: AsyncClient, tmp_path, monkeypatch):
+    """Test listing notes for a specific project."""
+    from app.config import settings
+    from app.services.search_index import SearchIndex
+    from app.models.search import IndexedNote
+
+    # Use temporary database
+    db_path = tmp_path / "test_index.db"
+    monkeypatch.setattr(settings, "index_db_path", db_path)
+
+    # Create index and add notes
+    index = SearchIndex(db_path)
+    await index.initialize()
+
+    indexed_note = IndexedNote(
+        vault_name="test_vault",
+        relative_path="test_note.md",
+        title="Test Note",
+        note_type="note",
+        project="test-project",
+        content="Test content",
+        tags=[],
+        file_hash="test_hash",
+    )
+
+    await index.index_note(indexed_note)
+    await index.close()
+
+    response = await client.get("/api/projects/test-project/notes")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["project"] == "test-project"
+    assert "notes" in data
+    assert len(data["notes"]) >= 1
+
+
+@pytest.mark.asyncio
+async def test_list_project_notes_not_found(client: AsyncClient, tmp_path, monkeypatch):
+    """Test listing notes for non-existent project."""
+    from app.config import settings
+    from pathlib import Path
+
+    # Use temporary database
+    db_path = tmp_path / "test_index.db"
+    monkeypatch.setattr(settings, "index_db_path", db_path)
+
+    response = await client.get("/api/projects/nonexistent/notes")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["project"] == "nonexistent"
+    assert data["total_count"] == 0
+    assert len(data["notes"]) == 0
+
+
+@pytest.mark.asyncio
+async def test_create_project_success(client: AsyncClient):
+    """Test creating a valid project."""
+    response = await client.post(
+        "/api/projects", json={"project_name": "new-project"}
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["project"] == "new-project"
+    assert data["status"] == "created"
+
+
+@pytest.mark.asyncio
+async def test_create_project_invalid_name(client: AsyncClient):
+    """Test creating a project with invalid name."""
+    response = await client.post(
+        "/api/projects", json={"project_name": "invalid project name!"}
+    )
+    assert response.status_code == 400
+    assert "alphanumeric" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_create_project_empty_name(client: AsyncClient):
+    """Test creating a project with empty name."""
+    response = await client.post("/api/projects", json={"project_name": ""})
+    assert response.status_code == 400
+    assert "empty" in response.json()["detail"].lower()

--- a/mcp-server/src/client.ts
+++ b/mcp-server/src/client.ts
@@ -153,4 +153,72 @@ export class ApiClient {
     }
     return response.json();
   }
+
+  /**
+   * List all projects.
+   */
+  async listProjects(): Promise<{ projects: Array<{ name: string; note_count: number }> }> {
+    const response = await fetch(`${this.baseUrl}/api/projects`);
+    if (!response.ok) {
+      throw new Error(`Failed to list projects: ${response.statusText}`);
+    }
+    return response.json();
+  }
+
+  /**
+   * List notes for a specific project.
+   */
+  async listProjectNotes(
+    projectName: string,
+    limit?: number,
+    offset?: number
+  ): Promise<{
+    project: string;
+    notes: Array<{
+      note_id: number;
+      title: string;
+      permalink: string | null;
+      note_type: string;
+      updated_at: string | null;
+    }>;
+    total_count: number;
+    limit: number;
+    offset: number;
+  }> {
+    const queryParams = new URLSearchParams();
+    if (limit) queryParams.append('limit', limit.toString());
+    if (offset) queryParams.append('offset', offset.toString());
+
+    const url = `${this.baseUrl}/api/projects/${encodeURIComponent(projectName)}/notes${queryParams.toString() ? `?${queryParams}` : ''}`;
+    const response = await fetch(url);
+    if (!response.ok) {
+      if (response.status === 404) {
+        throw new Error(`Project "${projectName}" not found`);
+      }
+      throw new Error(`Failed to list project notes: ${response.statusText}`);
+    }
+    return response.json();
+  }
+
+  /**
+   * Create a new project.
+   */
+  async createProject(projectName: string): Promise<{
+    project: string;
+    status: string;
+    message: string;
+  }> {
+    const response = await fetch(`${this.baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ project_name: projectName }),
+    });
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({ detail: response.statusText }));
+      throw new Error(`Failed to create project: ${error.detail || response.statusText}`);
+    }
+    return response.json();
+  }
 }

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -12,11 +12,20 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import { handleBuildContext } from './tools/context.js';
 import {
+  handleGraphSimilar,
+  handleGraphTraverse,
+} from './tools/graph.js';
+import {
   handleMemRead,
   handleMemSearch,
   handleMemWrite,
   memoryTools,
 } from './tools/memory.js';
+import {
+  handleProjectCreate,
+  handleProjectList,
+  handleProjectSwitch,
+} from './tools/project.js';
 
 /**
  * Initialize and start the MCP server.
@@ -84,6 +93,56 @@ async function main(): Promise<void> {
               {
                 type: 'text',
                 text: JSON.stringify(await handleBuildContext(args as Parameters<typeof handleBuildContext>[0]), null, 2),
+              },
+            ],
+          };
+
+        case 'graph_traverse':
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(await handleGraphTraverse(args as Parameters<typeof handleGraphTraverse>[0]), null, 2),
+              },
+            ],
+          };
+
+        case 'graph_similar':
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(await handleGraphSimilar(args as Parameters<typeof handleGraphSimilar>[0]), null, 2),
+              },
+            ],
+          };
+
+        case 'project_list':
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(await handleProjectList(), null, 2),
+              },
+            ],
+          };
+
+        case 'project_switch':
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(await handleProjectSwitch(args as Parameters<typeof handleProjectSwitch>[0]), null, 2),
+              },
+            ],
+          };
+
+        case 'project_create':
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(await handleProjectCreate(args as Parameters<typeof handleProjectCreate>[0]), null, 2),
               },
             ],
           };

--- a/mcp-server/src/tools/__init__.ts
+++ b/mcp-server/src/tools/__init__.ts
@@ -5,3 +5,4 @@
 export * from './context.js';
 export * from './graph.js';
 export * from './memory.js';
+export * from './project.js';

--- a/mcp-server/src/tools/memory.ts
+++ b/mcp-server/src/tools/memory.ts
@@ -13,6 +13,12 @@ import {
   handleGraphSimilar,
   handleGraphTraverse,
 } from './graph.js';
+import {
+  handleProjectCreate,
+  handleProjectList,
+  handleProjectSwitch,
+  projectTools,
+} from './project.js';
 
 const API_BASE_URL = process.env.OBSIDIAN_MEMORY_API_URL || 'http://localhost:8000';
 const client = new ApiClient(API_BASE_URL);
@@ -23,6 +29,7 @@ const client = new ApiClient(API_BASE_URL);
 export const memoryTools: Tool[] = [
   buildContextTool,
   ...graphTools,
+  ...projectTools,
   {
     name: 'mem_read',
     description: 'Read a note from Obsidian-Memory by ID, permalink, or search query. Returns the full note content with metadata.',

--- a/mcp-server/src/tools/project.ts
+++ b/mcp-server/src/tools/project.ts
@@ -1,0 +1,115 @@
+/**
+ * Project management tools for Obsidian-Memory MCP server.
+ */
+
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import { ApiClient } from '../client.js';
+
+const API_BASE_URL = process.env.OBSIDIAN_MEMORY_API_URL || 'http://localhost:8000';
+const client = new ApiClient(API_BASE_URL);
+
+/**
+ * Tool definitions for project operations.
+ */
+export const projectTools: Tool[] = [
+  {
+    name: 'project_list',
+    description:
+      'List all projects with their note counts. Returns projects sorted by note count (descending).',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+  },
+  {
+    name: 'project_switch',
+    description:
+      'Switch to a project context. Returns project details and recent notes. This is informational - actual project filtering happens in other tools.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        project_name: {
+          type: 'string',
+          description: 'Name of the project to switch to',
+        },
+        limit: {
+          type: 'number',
+          description: 'Number of recent notes to return (default: 10)',
+        },
+      },
+      required: ['project_name'],
+    },
+  },
+  {
+    name: 'project_create',
+    description:
+      'Create a new project. Projects are created implicitly when notes are added, but this validates the project name.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        project_name: {
+          type: 'string',
+          description: 'Name of the project to create (alphanumeric, dash, underscore only)',
+        },
+      },
+      required: ['project_name'],
+    },
+  },
+];
+
+/**
+ * Handle project_list tool call.
+ */
+export async function handleProjectList(): Promise<{
+  projects: Array<{ name: string; note_count: number }>;
+}> {
+  const result = await client.listProjects();
+  return result;
+}
+
+/**
+ * Handle project_switch tool call.
+ */
+export async function handleProjectSwitch(args: {
+  project_name: string;
+  limit?: number;
+}): Promise<{
+  project: string;
+  note_count: number;
+  recent_notes: Array<{
+    note_id: number;
+    title: string;
+    permalink: string | null;
+    note_type: string;
+    updated_at: string | null;
+  }>;
+}> {
+  const projectNotes = await client.listProjectNotes(
+    args.project_name,
+    args.limit || 10,
+    0
+  );
+
+  // Get project list to find note count
+  const projects = await client.listProjects();
+  const project = projects.projects.find((p) => p.name === args.project_name);
+
+  return {
+    project: args.project_name,
+    note_count: project?.note_count || projectNotes.total_count,
+    recent_notes: projectNotes.notes,
+  };
+}
+
+/**
+ * Handle project_create tool call.
+ */
+export async function handleProjectCreate(args: {
+  project_name: string;
+}): Promise<{
+  project: string;
+  status: string;
+  message: string;
+}> {
+  return await client.createProject(args.project_name);
+}

--- a/mcp-server/tests/project.test.ts
+++ b/mcp-server/tests/project.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests for project management MCP tools.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+  handleProjectCreate,
+  handleProjectList,
+  handleProjectSwitch,
+  projectTools,
+} from '../src/tools/project.js';
+
+describe('Project Tools', () => {
+  describe('Tool Schemas', () => {
+    test('project_list tool has correct schema', () => {
+      const tool = projectTools.find((t) => t.name === 'project_list');
+      expect(tool).toBeDefined();
+      expect(tool?.inputSchema).toEqual({
+        type: 'object',
+        properties: {},
+      });
+    });
+
+    test('project_switch tool has correct schema', () => {
+      const tool = projectTools.find((t) => t.name === 'project_switch');
+      expect(tool).toBeDefined();
+      expect(tool?.inputSchema.type).toBe('object');
+      expect(tool?.inputSchema.properties?.project_name).toBeDefined();
+      expect(tool?.inputSchema.properties?.limit).toBeDefined();
+      expect(tool?.inputSchema.required).toContain('project_name');
+    });
+
+    test('project_create tool has correct schema', () => {
+      const tool = projectTools.find((t) => t.name === 'project_create');
+      expect(tool).toBeDefined();
+      expect(tool?.inputSchema.type).toBe('object');
+      expect(tool?.inputSchema.properties?.project_name).toBeDefined();
+      expect(tool?.inputSchema.required).toContain('project_name');
+    });
+  });
+
+  // Integration tests require a running backend
+  // These are skipped for now
+  describe.skip('Integration Tests', () => {
+    test('handleProjectList returns projects', async () => {
+      const result = await handleProjectList();
+      expect(result).toHaveProperty('projects');
+      expect(Array.isArray(result.projects)).toBe(true);
+    });
+
+    test('handleProjectSwitch returns project info', async () => {
+      const result = await handleProjectSwitch({ project_name: 'test-project' });
+      expect(result).toHaveProperty('project');
+      expect(result).toHaveProperty('note_count');
+      expect(result).toHaveProperty('recent_notes');
+    });
+
+    test('handleProjectCreate validates project name', async () => {
+      const result = await handleProjectCreate({ project_name: 'valid-project' });
+      expect(result).toHaveProperty('project');
+      expect(result).toHaveProperty('status');
+    });
+  });
+});


### PR DESCRIPTION
Implements project management tools for the MCP server.

## Changes
- Integrated graph_traverse and graph_similar into main MCP server
- Created project management API endpoints (list, list notes, create)
- Implemented project_list, project_switch, and project_create MCP tools
- Added project methods to ApiClient
- Created comprehensive test suite (7 backend tests, all passing)

## Testing
All 7 backend API tests pass successfully.

Part of Phase 4: MCP Server implementation.