### PR TITLE
feat: implement session management tools for MCP server

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -41,7 +41,7 @@
 ### Priority: High
 - [x] **L** Graph tools integration (graph_traverse, graph_similar)
 - [x] **M** Project tools (project_list, project_switch, project_create)
-- [ ] **L** Session tools (session_observe, session_summary, session_context)
+- [x] **L** Session tools (session_observe, session_summary, session_context)
 - [ ] **M** SSE transport support
 
 ## Phase 5-8: See specs/ for details

--- a/backend/app/api/sessions.py
+++ b/backend/app/api/sessions.py
@@ -1,0 +1,197 @@
+"""Session management API endpoints."""
+
+from typing import Any
+
+from fastapi import APIRouter, Body, Depends, HTTPException
+
+from app.models.session import (
+    SessionContextRequest,
+    SessionEventType,
+    SessionObserveRequest,
+)
+from app.services.ai_processor import AIProcessor
+from app.services.session_manager import SessionManager
+
+router = APIRouter(prefix="/api/sessions", tags=["sessions"])
+
+
+def get_session_manager() -> SessionManager:
+    """Get session manager instance."""
+    return SessionManager()
+
+
+@router.post("")
+async def create_session(
+    project: str | None = Body(None, embed=True),
+    session_manager: SessionManager = Depends(get_session_manager),
+) -> dict[str, Any]:
+    """Create a new session.
+
+    Args:
+        project: Optional project name
+        session_manager: Session manager dependency
+
+    Returns:
+        Created session information
+    """
+    session = await session_manager.create_session(project=project)
+    return {
+        "session_id": session.session_id,
+        "project": session.project,
+        "started_at": session.started_at.isoformat(),
+        "status": session.status,
+    }
+
+
+@router.post("/observe")
+async def observe_event(
+    request: SessionObserveRequest,
+    session_manager: SessionManager = Depends(get_session_manager),
+) -> dict[str, Any]:
+    """Add an observation/event to a session.
+
+    Args:
+        request: Observation request
+        session_manager: Session manager dependency
+
+    Returns:
+        Updated session information
+    """
+    try:
+        session = await session_manager.observe_event(
+            session_id=request.session_id,
+            event_type=request.event_type,
+            content=request.content,
+            metadata=request.metadata,
+        )
+        return {
+            "session_id": session.session_id,
+            "event_count": len(session.events),
+            "status": session.status,
+        }
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+
+
+@router.post("/{session_id}/summary")
+async def summarize_session(
+    session_id: str,
+    session_manager: SessionManager = Depends(get_session_manager),
+    ai_processor: AIProcessor | None = Depends(lambda: AIProcessor()),
+) -> dict[str, Any]:
+    """Generate AI summary for a session.
+
+    Args:
+        session_id: Session identifier
+        session_manager: Session manager dependency
+        ai_processor: AI processor dependency
+
+    Returns:
+        Session summary
+    """
+    try:
+        summary = await session_manager.summarize_session(
+            session_id=session_id, ai_processor=ai_processor
+        )
+        return summary
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+
+
+@router.post("/context")
+async def get_session_context(
+    request: SessionContextRequest,
+    session_manager: SessionManager = Depends(get_session_manager),
+) -> dict[str, Any]:
+    """Get context for a session.
+
+    Args:
+        request: Context request
+        session_manager: Session manager dependency
+
+    Returns:
+        Session context
+    """
+    try:
+        context = await session_manager.get_session_context(
+            session_id=request.session_id,
+            include_events=request.include_events,
+            include_summary=request.include_summary,
+            limit=request.limit,
+        )
+        return context
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+
+
+@router.get("/{session_id}")
+async def get_session(
+    session_id: str,
+    session_manager: SessionManager = Depends(get_session_manager),
+) -> dict[str, Any]:
+    """Get a session by ID.
+
+    Args:
+        session_id: Session identifier
+        session_manager: Session manager dependency
+
+    Returns:
+        Session information
+    """
+    session = await session_manager.get_session(session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail=f"Session {session_id} not found")
+
+    return {
+        "session_id": session.session_id,
+        "project": session.project,
+        "started_at": session.started_at.isoformat(),
+        "ended_at": session.ended_at.isoformat() if session.ended_at else None,
+        "status": session.status,
+        "event_count": len(session.events),
+    }
+
+
+@router.post("/{session_id}/end")
+async def end_session(
+    session_id: str,
+    session_manager: SessionManager = Depends(get_session_manager),
+) -> dict[str, Any]:
+    """End a session.
+
+    Args:
+        session_id: Session identifier
+        session_manager: Session manager dependency
+
+    Returns:
+        Updated session information
+    """
+    try:
+        session = await session_manager.end_session(session_id)
+        return {
+            "session_id": session.session_id,
+            "status": session.status,
+            "ended_at": session.ended_at.isoformat() if session.ended_at else None,
+        }
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+
+
+@router.get("")
+async def list_sessions(
+    project: str | None = None,
+    limit: int = 50,
+    session_manager: SessionManager = Depends(get_session_manager),
+) -> dict[str, Any]:
+    """List sessions.
+
+    Args:
+        project: Optional project filter
+        limit: Maximum number of sessions to return
+        session_manager: Session manager dependency
+
+    Returns:
+        List of sessions
+    """
+    sessions = await session_manager.list_sessions(project=project, limit=limit)
+    return {"sessions": sessions}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 
 from app.api.notes import router as notes_router
 from app.api.projects import router as projects_router
+from app.api.sessions import router as sessions_router
 from app.config import settings
 
 app = FastAPI(
@@ -16,6 +17,7 @@ app = FastAPI(
 # Include routers
 app.include_router(notes_router)
 app.include_router(projects_router)
+app.include_router(sessions_router)
 
 
 @app.get("/")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -39,6 +39,13 @@ from app.models.search import (
     SearchResults,
     SortOrder,
 )
+from app.models.session import (
+    Session,
+    SessionEvent,
+    SessionEventType,
+    SessionContextRequest,
+    SessionObserveRequest,
+)
 from app.models.vault import (
     VaultConfig,
     VaultFile,
@@ -70,6 +77,11 @@ __all__ = [
     "SearchQuery",
     "SearchResult",
     "SearchResults",
+    "Session",
+    "SessionContextRequest",
+    "SessionEvent",
+    "SessionEventType",
+    "SessionObserveRequest",
     "SessionSummary",
     "SortOrder",
     "VaultConfig",

--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -1,0 +1,63 @@
+"""Data models for session management."""
+
+from datetime import datetime
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+
+class SessionEventType(str, Enum):
+    """Type of session event."""
+
+    OBSERVATION = "observation"
+    DECISION = "decision"
+    ERROR = "error"
+    SOLUTION = "solution"
+    TOOL_USE = "tool_use"
+    FILE_EDIT = "file_edit"
+    COMMAND = "command"
+    RESEARCH = "research"
+    USER_PROMPT = "user_prompt"
+
+
+class SessionEvent(BaseModel):
+    """A single event in a session."""
+
+    event_type: SessionEventType = Field(..., description="Type of event")
+    content: str = Field(..., description="Event content")
+    timestamp: datetime = Field(default_factory=datetime.now, description="Event timestamp")
+    metadata: dict = Field(
+        default_factory=dict, description="Additional event metadata"
+    )
+
+
+class Session(BaseModel):
+    """A session record."""
+
+    session_id: str = Field(..., description="Unique session identifier")
+    project: str | None = Field(default=None, description="Associated project")
+    started_at: datetime = Field(default_factory=datetime.now, description="Session start time")
+    ended_at: datetime | None = Field(default=None, description="Session end time")
+    events: list[SessionEvent] = Field(
+        default_factory=list, description="Session events"
+    )
+    summary: dict | None = Field(default=None, description="AI-generated summary")
+    status: str = Field(default="active", description="Session status (active, completed)")
+
+
+class SessionObserveRequest(BaseModel):
+    """Request to observe/add an event to a session."""
+
+    session_id: str = Field(..., description="Session ID")
+    event_type: SessionEventType = Field(..., description="Event type")
+    content: str = Field(..., description="Event content")
+    metadata: dict = Field(default_factory=dict, description="Additional metadata")
+
+
+class SessionContextRequest(BaseModel):
+    """Request for session context."""
+
+    session_id: str = Field(..., description="Session ID")
+    include_events: bool = Field(default=True, description="Include session events")
+    include_summary: bool = Field(default=True, description="Include AI summary if available")
+    limit: int = Field(default=50, description="Maximum number of events to return")

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -4,6 +4,7 @@ from app.services.ai_processor import AIProcessor
 from app.services.graph_engine import GraphEngine
 from app.services.markdown_parser import MarkdownParser
 from app.services.search_index import SearchIndex
+from app.services.session_manager import SessionManager
 from app.services.vault_manager import VaultManager
 from app.services.wikilink_resolver import WikilinkResolver
 
@@ -12,6 +13,7 @@ __all__ = [
     "GraphEngine",
     "MarkdownParser",
     "SearchIndex",
+    "SessionManager",
     "VaultManager",
     "WikilinkResolver",
 ]

--- a/backend/app/services/session_manager.py
+++ b/backend/app/services/session_manager.py
@@ -1,0 +1,294 @@
+"""Session management service."""
+
+import json
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import aiofiles
+
+from app.config import settings
+from app.models.session import (
+    Session,
+    SessionEvent,
+    SessionEventType,
+)
+from app.services.ai_processor import AIProcessor
+from app.services.exceptions import AIProcessorUnavailableError
+
+
+class SessionManager:
+    """Manages session tracking and storage."""
+
+    def __init__(self, storage_path: Path | None = None) -> None:
+        """Initialize session manager.
+
+        Args:
+            storage_path: Path to store session files (defaults to ~/.obsidian-memory/sessions)
+        """
+        if storage_path is None:
+            storage_path = Path.home() / ".obsidian-memory" / "sessions"
+        self.storage_path = storage_path
+        self.storage_path.mkdir(parents=True, exist_ok=True)
+        self._sessions: dict[str, Session] = {}
+
+    def _get_session_file(self, session_id: str) -> Path:
+        """Get path to session file."""
+        return self.storage_path / f"{session_id}.json"
+
+    async def create_session(
+        self, project: str | None = None, session_id: str | None = None
+    ) -> Session:
+        """Create a new session.
+
+        Args:
+            project: Optional project name
+            session_id: Optional custom session ID (defaults to UUID)
+
+        Returns:
+            Created session
+        """
+        if session_id is None:
+            session_id = str(uuid.uuid4())
+
+        session = Session(
+            session_id=session_id,
+            project=project,
+            started_at=datetime.now(),
+            status="active",
+        )
+
+        self._sessions[session_id] = session
+        await self._save_session(session)
+
+        return session
+
+    async def get_session(self, session_id: str) -> Session | None:
+        """Get a session by ID.
+
+        Args:
+            session_id: Session identifier
+
+        Returns:
+            Session if found, None otherwise
+        """
+        # Check in-memory cache first
+        if session_id in self._sessions:
+            return self._sessions[session_id]
+
+        # Try to load from disk
+        session_file = self._get_session_file(session_id)
+        if session_file.exists():
+            try:
+                async with aiofiles.open(session_file, "r", encoding="utf-8") as f:
+                    data = json.loads(await f.read())
+                    session = Session(**data)
+                    self._sessions[session_id] = session
+                    return session
+            except Exception:
+                return None
+
+        return None
+
+    async def observe_event(
+        self,
+        session_id: str,
+        event_type: SessionEventType,
+        content: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> Session:
+        """Add an observation/event to a session.
+
+        Args:
+            session_id: Session identifier
+            event_type: Type of event
+            content: Event content
+            metadata: Optional metadata
+
+        Returns:
+            Updated session
+
+        Raises:
+            ValueError: If session not found
+        """
+        session = await self.get_session(session_id)
+        if not session:
+            raise ValueError(f"Session {session_id} not found")
+
+        event = SessionEvent(
+            event_type=event_type,
+            content=content,
+            timestamp=datetime.now(),
+            metadata=metadata or {},
+        )
+
+        session.events.append(event)
+        self._sessions[session_id] = session
+        await self._save_session(session)
+
+        return session
+
+    async def end_session(self, session_id: str) -> Session:
+        """End a session.
+
+        Args:
+            session_id: Session identifier
+
+        Returns:
+            Updated session
+
+        Raises:
+            ValueError: If session not found
+        """
+        session = await self.get_session(session_id)
+        if not session:
+            raise ValueError(f"Session {session_id} not found")
+
+        session.ended_at = datetime.now()
+        session.status = "completed"
+        self._sessions[session_id] = session
+        await self._save_session(session)
+
+        return session
+
+    async def summarize_session(
+        self, session_id: str, ai_processor: AIProcessor | None = None
+    ) -> dict[str, Any]:
+        """Generate AI summary for a session.
+
+        Args:
+            session_id: Session identifier
+            ai_processor: Optional AI processor (creates one if not provided)
+
+        Returns:
+            Session summary dictionary
+        """
+        session = await self.get_session(session_id)
+        if not session:
+            raise ValueError(f"Session {session_id} not found")
+
+        # Build session content from events
+        event_lines = []
+        for event in session.events:
+            event_lines.append(
+                f"[{event.event_type.value}] {event.timestamp.isoformat()}: {event.content}"
+            )
+        session_content = "\n".join(event_lines)
+
+        # Use AI processor to summarize
+        if ai_processor is None:
+            ai_processor = AIProcessor()
+
+        try:
+            summary = await ai_processor.summarize_session(session_content)
+            session.summary = summary.model_dump()
+            await self._save_session(session)
+            return session.summary
+        except AIProcessorUnavailableError:
+            # Return basic summary if AI unavailable
+            return {
+                "key_learnings": [],
+                "decisions": [],
+                "errors_encountered": [],
+                "solutions_found": [],
+                "next_steps": [],
+                "summary_text": f"Session with {len(session.events)} events",
+                "compression_ratio": 0.0,
+            }
+
+    async def get_session_context(
+        self,
+        session_id: str,
+        include_events: bool = True,
+        include_summary: bool = True,
+        limit: int = 50,
+    ) -> dict[str, Any]:
+        """Get context for a session.
+
+        Args:
+            session_id: Session identifier
+            include_events: Whether to include events
+            include_summary: Whether to include summary
+            limit: Maximum number of events to return
+
+        Returns:
+            Session context dictionary
+        """
+        session = await self.get_session(session_id)
+        if not session:
+            raise ValueError(f"Session {session_id} not found")
+
+        context: dict[str, Any] = {
+            "session_id": session.session_id,
+            "project": session.project,
+            "started_at": session.started_at.isoformat(),
+            "ended_at": session.ended_at.isoformat() if session.ended_at else None,
+            "status": session.status,
+            "event_count": len(session.events),
+        }
+
+        if include_events:
+            events = session.events[-limit:] if limit > 0 else session.events
+            context["events"] = [
+                {
+                    "event_type": e.event_type.value,
+                    "content": e.content,
+                    "timestamp": e.timestamp.isoformat(),
+                    "metadata": e.metadata,
+                }
+                for e in events
+            ]
+
+        if include_summary and session.summary:
+            context["summary"] = session.summary
+
+        return context
+
+    async def _save_session(self, session: Session) -> None:
+        """Save session to disk."""
+        session_file = self._get_session_file(session.session_id)
+        async with aiofiles.open(session_file, "w", encoding="utf-8") as f:
+            await f.write(json.dumps(session.model_dump(), default=str, indent=2))
+
+    async def list_sessions(
+        self, project: str | None = None, limit: int = 50
+    ) -> list[dict[str, Any]]:
+        """List sessions.
+
+        Args:
+            project: Optional project filter
+            limit: Maximum number of sessions to return
+
+        Returns:
+            List of session summaries
+        """
+        sessions = []
+
+        # Load all session files
+        for session_file in self.storage_path.glob("*.json"):
+            try:
+                async with aiofiles.open(session_file, "r", encoding="utf-8") as f:
+                    data = json.loads(await f.read())
+                    session = Session(**data)
+
+                    if project is None or session.project == project:
+                        sessions.append(
+                            {
+                                "session_id": session.session_id,
+                                "project": session.project,
+                                "started_at": session.started_at.isoformat(),
+                                "ended_at": session.ended_at.isoformat()
+                                if session.ended_at
+                                else None,
+                                "status": session.status,
+                                "event_count": len(session.events),
+                            }
+                        )
+            except Exception:
+                continue
+
+        # Sort by started_at descending
+        sessions.sort(key=lambda x: x["started_at"], reverse=True)
+
+        return sessions[:limit]

--- a/backend/tests/api/test_sessions.py
+++ b/backend/tests/api/test_sessions.py
@@ -1,0 +1,142 @@
+"""Tests for session management API endpoints."""
+
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+from app.services.session_manager import SessionManager
+
+
+@pytest.fixture
+def temp_storage(tmp_path: Path) -> Path:
+    """Create temporary storage directory."""
+    storage = tmp_path / "sessions"
+    storage.mkdir(parents=True)
+    return storage
+
+
+@pytest.fixture
+def session_manager(temp_storage: Path) -> SessionManager:
+    """Create session manager with temp storage."""
+    return SessionManager(storage_path=temp_storage)
+
+
+@pytest.fixture
+async def client(session_manager: SessionManager):
+    """Create test client with mocked session manager."""
+    from app.api import sessions
+
+    # Override the dependency
+    app.dependency_overrides[sessions.get_session_manager] = lambda: session_manager
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        yield ac
+
+    # Clean up
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_create_session(client: AsyncClient):
+    """Test creating a new session."""
+    response = await client.post("/api/sessions", json={"project": None})
+    assert response.status_code == 200
+    data = response.json()
+    assert "session_id" in data
+    assert data["status"] == "active"
+
+
+@pytest.mark.asyncio
+async def test_observe_event(client: AsyncClient, session_manager: SessionManager):
+    """Test observing an event in a session."""
+    # Create a session first
+    session = await session_manager.create_session()
+
+    response = await client.post(
+        "/api/sessions/observe",
+        json={
+            "session_id": session.session_id,
+            "event_type": "observation",
+            "content": "Test observation",
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["session_id"] == session.session_id
+    assert data["event_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_session(client: AsyncClient, session_manager: SessionManager):
+    """Test getting a session by ID."""
+    session = await session_manager.create_session(project="test-project")
+
+    response = await client.get(f"/api/sessions/{session.session_id}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["session_id"] == session.session_id
+    assert data["project"] == "test-project"
+
+
+@pytest.mark.asyncio
+async def test_get_session_not_found(client: AsyncClient):
+    """Test getting a non-existent session."""
+    response = await client.get("/api/sessions/nonexistent-session")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_end_session(client: AsyncClient, session_manager: SessionManager):
+    """Test ending a session."""
+    session = await session_manager.create_session()
+
+    response = await client.post(f"/api/sessions/{session.session_id}/end")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "completed"
+    assert data["ended_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_list_sessions(client: AsyncClient, session_manager: SessionManager):
+    """Test listing sessions."""
+    await session_manager.create_session(project="test-project")
+    await session_manager.create_session(project="test-project")
+
+    response = await client.get("/api/sessions")
+    assert response.status_code == 200
+    data = response.json()
+    assert "sessions" in data
+    assert len(data["sessions"]) >= 2
+
+
+@pytest.mark.asyncio
+async def test_get_session_context(
+    client: AsyncClient, session_manager: SessionManager
+):
+    """Test getting session context."""
+    from app.models.session import SessionEventType
+
+    session = await session_manager.create_session()
+    await session_manager.observe_event(
+        session.session_id, SessionEventType.OBSERVATION, "Test event"
+    )
+
+    response = await client.post(
+        "/api/sessions/context",
+        json={
+            "session_id": session.session_id,
+            "include_events": True,
+            "include_summary": False,
+            "limit": 50,
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["session_id"] == session.session_id
+    assert "events" in data
+    assert len(data["events"]) >= 1

--- a/mcp-server/src/client.ts
+++ b/mcp-server/src/client.ts
@@ -221,4 +221,131 @@ export class ApiClient {
     }
     return response.json();
   }
+
+  /**
+   * Create a new session.
+   */
+  async createSession(project?: string | null): Promise<{
+    session_id: string;
+    project: string | null;
+    started_at: string;
+    status: string;
+  }> {
+    const response = await fetch(`${this.baseUrl}/api/sessions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ project: project || null }),
+    });
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({ detail: response.statusText }));
+      throw new Error(`Failed to create session: ${error.detail || response.statusText}`);
+    }
+    return response.json();
+  }
+
+  /**
+   * Observe/add an event to a session.
+   */
+  async observeSessionEvent(
+    sessionId: string,
+    eventType: string,
+    content: string,
+    metadata?: Record<string, unknown>
+  ): Promise<{
+    session_id: string;
+    event_count: number;
+    status: string;
+  }> {
+    const response = await fetch(`${this.baseUrl}/api/sessions/observe`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        session_id: sessionId,
+        event_type: eventType,
+        content: content,
+        metadata: metadata || {},
+      }),
+    });
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({ detail: response.statusText }));
+      throw new Error(`Failed to observe event: ${error.detail || response.statusText}`);
+    }
+    return response.json();
+  }
+
+  /**
+   * Summarize a session.
+   */
+  async summarizeSession(sessionId: string): Promise<{
+    key_learnings: string[];
+    decisions: string[];
+    errors_encountered: string[];
+    solutions_found: string[];
+    next_steps: string[];
+    summary_text: string;
+    compression_ratio: number;
+  }> {
+    const response = await fetch(`${this.baseUrl}/api/sessions/${sessionId}/summary`, {
+      method: 'POST',
+    });
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({ detail: response.statusText }));
+      throw new Error(`Failed to summarize session: ${error.detail || response.statusText}`);
+    }
+    return response.json();
+  }
+
+  /**
+   * Get session context.
+   */
+  async getSessionContext(
+    sessionId: string,
+    includeEvents: boolean = true,
+    includeSummary: boolean = true,
+    limit: number = 50
+  ): Promise<{
+    session_id: string;
+    project: string | null;
+    started_at: string;
+    ended_at: string | null;
+    status: string;
+    event_count: number;
+    events?: Array<{
+      event_type: string;
+      content: string;
+      timestamp: string;
+      metadata: Record<string, unknown>;
+    }>;
+    summary?: {
+      key_learnings: string[];
+      decisions: string[];
+      errors_encountered: string[];
+      solutions_found: string[];
+      next_steps: string[];
+      summary_text: string;
+      compression_ratio: number;
+    };
+  }> {
+    const response = await fetch(`${this.baseUrl}/api/sessions/context`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        session_id: sessionId,
+        include_events: includeEvents,
+        include_summary: includeSummary,
+        limit: limit,
+      }),
+    });
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({ detail: response.statusText }));
+      throw new Error(`Failed to get session context: ${error.detail || response.statusText}`);
+    }
+    return response.json();
+  }
 }

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -26,6 +26,11 @@ import {
   handleProjectList,
   handleProjectSwitch,
 } from './tools/project.js';
+import {
+  handleSessionContext,
+  handleSessionObserve,
+  handleSessionSummary,
+} from './tools/session.js';
 
 /**
  * Initialize and start the MCP server.
@@ -143,6 +148,36 @@ async function main(): Promise<void> {
               {
                 type: 'text',
                 text: JSON.stringify(await handleProjectCreate(args as Parameters<typeof handleProjectCreate>[0]), null, 2),
+              },
+            ],
+          };
+
+        case 'session_observe':
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(await handleSessionObserve(args as Parameters<typeof handleSessionObserve>[0]), null, 2),
+              },
+            ],
+          };
+
+        case 'session_summary':
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(await handleSessionSummary(args as Parameters<typeof handleSessionSummary>[0]), null, 2),
+              },
+            ],
+          };
+
+        case 'session_context':
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(await handleSessionContext(args as Parameters<typeof handleSessionContext>[0]), null, 2),
               },
             ],
           };

--- a/mcp-server/src/tools/__init__.ts
+++ b/mcp-server/src/tools/__init__.ts
@@ -6,3 +6,4 @@ export * from './context.js';
 export * from './graph.js';
 export * from './memory.js';
 export * from './project.js';
+export * from './session.js';

--- a/mcp-server/src/tools/memory.ts
+++ b/mcp-server/src/tools/memory.ts
@@ -19,6 +19,12 @@ import {
   handleProjectSwitch,
   projectTools,
 } from './project.js';
+import {
+  handleSessionContext,
+  handleSessionObserve,
+  handleSessionSummary,
+  sessionTools,
+} from './session.js';
 
 const API_BASE_URL = process.env.OBSIDIAN_MEMORY_API_URL || 'http://localhost:8000';
 const client = new ApiClient(API_BASE_URL);
@@ -30,6 +36,7 @@ export const memoryTools: Tool[] = [
   buildContextTool,
   ...graphTools,
   ...projectTools,
+  ...sessionTools,
   {
     name: 'mem_read',
     description: 'Read a note from Obsidian-Memory by ID, permalink, or search query. Returns the full note content with metadata.',

--- a/mcp-server/src/tools/session.ts
+++ b/mcp-server/src/tools/session.ts
@@ -1,0 +1,172 @@
+/**
+ * Session management tools for Obsidian-Memory MCP server.
+ */
+
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import { ApiClient } from '../client.js';
+
+const API_BASE_URL = process.env.OBSIDIAN_MEMORY_API_URL || 'http://localhost:8000';
+const client = new ApiClient(API_BASE_URL);
+
+/**
+ * Tool definitions for session operations.
+ */
+export const sessionTools: Tool[] = [
+  {
+    name: 'session_observe',
+    description:
+      'Add an observation or event to a session. Use this to track decisions, errors, solutions, tool usage, file edits, etc.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        session_id: {
+          type: 'string',
+          description: 'Session ID (create one first if needed)',
+        },
+        event_type: {
+          type: 'string',
+          enum: [
+            'observation',
+            'decision',
+            'error',
+            'solution',
+            'tool_use',
+            'file_edit',
+            'command',
+            'research',
+            'user_prompt',
+          ],
+          description: 'Type of event',
+        },
+        content: {
+          type: 'string',
+          description: 'Event content/description',
+        },
+        metadata: {
+          type: 'object',
+          description: 'Optional metadata (e.g., file path, command, tool name)',
+        },
+      },
+      required: ['session_id', 'event_type', 'content'],
+    },
+  },
+  {
+    name: 'session_summary',
+    description:
+      'Generate an AI summary of a session. Extracts key learnings, decisions, errors, solutions, and next steps.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        session_id: {
+          type: 'string',
+          description: 'Session ID to summarize',
+        },
+      },
+      required: ['session_id'],
+    },
+  },
+  {
+    name: 'session_context',
+    description:
+      'Get context for a session including events and summary. Useful for loading session context into Claude.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        session_id: {
+          type: 'string',
+          description: 'Session ID',
+        },
+        include_events: {
+          type: 'boolean',
+          description: 'Include session events (default: true)',
+        },
+        include_summary: {
+          type: 'boolean',
+          description: 'Include AI summary if available (default: true)',
+        },
+        limit: {
+          type: 'number',
+          description: 'Maximum number of events to return (default: 50)',
+        },
+      },
+      required: ['session_id'],
+    },
+  },
+];
+
+/**
+ * Handle session_observe tool call.
+ */
+export async function handleSessionObserve(args: {
+  session_id: string;
+  event_type: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+}): Promise<{
+  session_id: string;
+  event_count: number;
+  status: string;
+}> {
+  return await client.observeSessionEvent(
+    args.session_id,
+    args.event_type,
+    args.content,
+    args.metadata
+  );
+}
+
+/**
+ * Handle session_summary tool call.
+ */
+export async function handleSessionSummary(args: {
+  session_id: string;
+}): Promise<{
+  key_learnings: string[];
+  decisions: string[];
+  errors_encountered: string[];
+  solutions_found: string[];
+  next_steps: string[];
+  summary_text: string;
+  compression_ratio: number;
+}> {
+  return await client.summarizeSession(args.session_id);
+}
+
+/**
+ * Handle session_context tool call.
+ */
+export async function handleSessionContext(args: {
+  session_id: string;
+  include_events?: boolean;
+  include_summary?: boolean;
+  limit?: number;
+}): Promise<{
+  session_id: string;
+  project: string | null;
+  started_at: string;
+  ended_at: string | null;
+  status: string;
+  event_count: number;
+  events?: Array<{
+    event_type: string;
+    content: string;
+    timestamp: string;
+    metadata: Record<string, unknown>;
+  }>;
+  summary?: {
+    key_learnings: string[];
+    decisions: string[];
+    errors_encountered: string[];
+    solutions_found: string[];
+    next_steps: string[];
+    summary_text: string;
+    compression_ratio: number;
+  };
+}> {
+  return await client.getSessionContext(
+    args.session_id,
+    args.include_events ?? true,
+    args.include_summary ?? true,
+    args.limit ?? 50
+  );
+}

--- a/mcp-server/tests/session.test.ts
+++ b/mcp-server/tests/session.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Tests for session management MCP tools.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+  handleSessionContext,
+  handleSessionObserve,
+  handleSessionSummary,
+  sessionTools,
+} from '../src/tools/session.js';
+
+describe('Session Tools', () => {
+  describe('Tool Schemas', () => {
+    test('session_observe tool has correct schema', () => {
+      const tool = sessionTools.find((t) => t.name === 'session_observe');
+      expect(tool).toBeDefined();
+      expect(tool?.inputSchema.type).toBe('object');
+      expect(tool?.inputSchema.properties?.session_id).toBeDefined();
+      expect(tool?.inputSchema.properties?.event_type).toBeDefined();
+      expect(tool?.inputSchema.properties?.content).toBeDefined();
+      expect(tool?.inputSchema.required).toContain('session_id');
+      expect(tool?.inputSchema.required).toContain('event_type');
+      expect(tool?.inputSchema.required).toContain('content');
+    });
+
+    test('session_summary tool has correct schema', () => {
+      const tool = sessionTools.find((t) => t.name === 'session_summary');
+      expect(tool).toBeDefined();
+      expect(tool?.inputSchema.type).toBe('object');
+      expect(tool?.inputSchema.properties?.session_id).toBeDefined();
+      expect(tool?.inputSchema.required).toContain('session_id');
+    });
+
+    test('session_context tool has correct schema', () => {
+      const tool = sessionTools.find((t) => t.name === 'session_context');
+      expect(tool).toBeDefined();
+      expect(tool?.inputSchema.type).toBe('object');
+      expect(tool?.inputSchema.properties?.session_id).toBeDefined();
+      expect(tool?.inputSchema.properties?.include_events).toBeDefined();
+      expect(tool?.inputSchema.properties?.include_summary).toBeDefined();
+      expect(tool?.inputSchema.properties?.limit).toBeDefined();
+      expect(tool?.inputSchema.required).toContain('session_id');
+    });
+  });
+
+  // Integration tests require a running backend
+  // These are skipped for now
+  describe.skip('Integration Tests', () => {
+    test('handleSessionObserve adds event to session', async () => {
+      const result = await handleSessionObserve({
+        session_id: 'test-session',
+        event_type: 'observation',
+        content: 'Test observation',
+      });
+      expect(result).toHaveProperty('session_id');
+      expect(result).toHaveProperty('event_count');
+    });
+
+    test('handleSessionSummary generates summary', async () => {
+      const result = await handleSessionSummary({ session_id: 'test-session' });
+      expect(result).toHaveProperty('key_learnings');
+      expect(result).toHaveProperty('summary_text');
+    });
+
+    test('handleSessionContext returns context', async () => {
+      const result = await handleSessionContext({ session_id: 'test-session' });
+      expect(result).toHaveProperty('session_id');
+      expect(result).toHaveProperty('event_count');
+    });
+  });
+});


### PR DESCRIPTION
Implements session management tools for the MCP server.

## Changes
- Created session management data models and SessionManager service
- Created session management API endpoints (create, observe, summary, context, list, end)
- Implemented session_observe, session_summary, and session_context MCP tools
- Integrated with AI processor for session summarization
- Added session methods to ApiClient
- Created comprehensive test suite (7 backend tests, all passing)

## Testing
All 7 backend API tests pass successfully.

Part of Phase 4: MCP Server implementation.